### PR TITLE
Don't crash Sys when build has suffix such as "icedtea"

### DIFF
--- a/reflekt/src/main/java/io/advantageous/boon/core/Sys.java
+++ b/reflekt/src/main/java/io/advantageous/boon/core/Sys.java
@@ -69,6 +69,11 @@ public class Sys {
         BigDecimal v = new BigDecimal ( "-1" );
         int b = -1;
         String sversion = System.getProperty ( "java.version" );
+        // get rid of build suffix, like ea or icedtea
+        int dash = sversion.indexOf("-");
+        if (dash != - 1) {
+            sversion = sversion.substring(0, dash);
+        }
         if ( sversion.indexOf ( "_" ) != -1 ) {
             final String[] split = sversion.split ( "_" );
             try {
@@ -96,15 +101,12 @@ public class Sys {
                 }
 
                 String build = split[ 1 ];
-                if (build.endsWith("-ea")) {
-                    build = build.substring(0, build.length() - 3);
-                }
                 b = Integer.parseInt ( build );
             } catch ( Exception ex ) {
                 ex.printStackTrace ();
                 System.err.println ( "Unable to determine build number or version" );
             }
-        } else if ("1.8.0".equals(sversion) || "1.8.0-ea".equals(sversion)) {
+        } else if ("1.8.0".equals(sversion)) {
             b = -1;
             v = new BigDecimal("1.8");
         } else {


### PR DESCRIPTION
You get a version like "1.7.0_09-icedtea" with [OpenJDK](http://openjdk.java.net/projects/icedtea).
