### PR TITLE
Remove useless (and wrong) hash collision attacks protection

### DIFF
--- a/json/src/test/java/io/advantageous/boon/json/JsonBugReports.java
+++ b/json/src/test/java/io/advantageous/boon/json/JsonBugReports.java
@@ -28,13 +28,12 @@
 
 package io.advantageous.boon.json;
 
-
 import org.junit.Test;
+import static org.junit.Assert.*;
 
 import java.util.Map;
 
 import static io.advantageous.boon.core.IO.puts;
-import static io.advantageous.boon.core.Exceptions.die;
 import static io.advantageous.boon.json.JsonFactory.fromJson;
 import static io.advantageous.boon.json.JsonFactory.toJson;
 
@@ -47,8 +46,7 @@ public class JsonBugReports {
         puts (map);
         puts (toJson(map));
 
-        boolean ok = toJson(map).equals("{\"docId\":111,\"empty\":\"\",\"serviceName\":\"cafe\"}") ||
-                die(toJson(map) );
+        assertTrue(toJson(map).contains("\"empty\":\"\""));
     }
 
 

--- a/reflekt/src/main/java/io/advantageous/boon/core/LazyMap.java
+++ b/reflekt/src/main/java/io/advantageous/boon/core/LazyMap.java
@@ -38,8 +38,6 @@ import java.util.*;
  */
 public class LazyMap extends AbstractMap<String, Object> {
 
-
-    final static boolean althashingThreshold = System.getProperty("jdk.map.althashing.threshold") != null;
     private final boolean delayMap;
     /* Holds the actual map that will be lazily created. */
     private Map<String, Object> map;
@@ -152,13 +150,7 @@ public class LazyMap extends AbstractMap<String, Object> {
 
     private void buildIfNeeded() {
         if (map == null) {
-
-            /** added to avoid hash collision attack. */
-            if (Sys.is1_7OrLater() && althashingThreshold) {
-                map = new LinkedHashMap<>(size, 0.01f);
-            } else {
-                map = new TreeMap<>();
-            }
+            map = new LinkedHashMap<>(size, 0.01f);
 
             for (int index = 0; index < size; index++) {
                 map.put(keys[index], values[index]);

--- a/reflekt/src/main/java/io/advantageous/boon/core/value/LazyValueMap.java
+++ b/reflekt/src/main/java/io/advantageous/boon/core/value/LazyValueMap.java
@@ -216,18 +216,8 @@ public class LazyValueMap extends AbstractMap<String, Object> implements ValueMa
         return map.entrySet();
     }
 
-    final static boolean althashingThreshold = System.getProperty("jdk.map.althashing.threshold") != null;
-
     private final void buildMap() {
-
-
-        /** added to avoid hash collision attack. */
-        if (Sys.is1_7OrLater() && althashingThreshold) {
-            map = new HashMap<>( items.length );
-        } else {
-            map = new TreeMap<>();
-        }
-
+        map = new HashMap<>( items.length );
 
         for ( Entry<String, Value> miv : items ) {
             if ( miv == null ) {


### PR DESCRIPTION
Since JDK8, HashMap and friends are [no longer sensible to hash collision attacks](https://docs.oracle.com/javase/8/docs/technotes/guides/collections/changes8.html).

As Boon is now compiled against JDK8, it's safe the remove the protection logic.

Then, if anyone is interested to backport, pleas be aware that the current logic is wrong, as it would pick a TreeMap under JDK8.

The condition should be "it's safe to use HashMap as long as you're running JDK8+, or jdk.map.althashing.threshold is defined".
